### PR TITLE
Fix from path in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Now, we are ready to define our `MyApp.Blog` with `NimblePublisher`:
 defmodule MyApp.Blog do
   use NimblePublisher,
     build: Post,
-    from: Application.app_dir(:my_app, "posts/**/*.md"),
+    from: "posts/**/*.md",
     as: :posts,
     highlighters: [:makeup_elixir, :makeup_erlang]
 


### PR DESCRIPTION
The `Application.app_dir(:my_app, "posts/**/*.md")` doesn't work out of the box.
In `dev` it is evaluated to `my_app/_build/dev/lib/tomaszkowal/posts/**/*.md` which is empty because the posts are in `my_app/posts/**/*.md`.

I checked that version without `app_dir` works with `MIX_ENV=prod`.
It obviously works with releases because they contain already compiled code.