### PR TITLE
code block with `elixir` lang identifier and "nohighlight" syntax attribute

### DIFF
--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -93,9 +93,9 @@ defmodule NimblePublisher do
   end
 
   # calls Highlighter.highlight/1 only when needed
-  defp highlight(html, %{syntax: "highlight"}) do
+  defp highlight(html, %{syntax: false}), do: html
+
+  defp highlight(html, _) do
     NimblePublisher.Highlighter.highlight(html)
   end
-
-  defp highlight(html, _), do: html
 end

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -41,6 +41,7 @@ defmodule NimblePublisher do
     entries =
       for path <- paths do
         {attrs, body} = parse_contents!(path, File.read!(path))
+
         body =
           body
           |> Earmark.as_html!(earmark_opts)
@@ -95,5 +96,6 @@ defmodule NimblePublisher do
   defp highlight(html, %{syntax: "highlight"}) do
     NimblePublisher.Highlighter.highlight(html)
   end
+
   defp highlight(html, _), do: html
 end

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -41,7 +41,11 @@ defmodule NimblePublisher do
     entries =
       for path <- paths do
         {attrs, body} = parse_contents!(path, File.read!(path))
-        body = body |> Earmark.as_html!(earmark_opts) |> NimblePublisher.Highlighter.highlight()
+        body =
+          body
+          |> Earmark.as_html!(earmark_opts)
+          |> highlight(attrs)
+
         builder.build(path, attrs, body)
       end
 
@@ -86,4 +90,10 @@ defmodule NimblePublisher do
         end
     end
   end
+
+  # calls Highlighter.highlight/1 only when needed
+  defp highlight(html, %{syntax: "highlight"}) do
+    NimblePublisher.Highlighter.highlight(html)
+  end
+  defp highlight(html, _), do: html
 end

--- a/test/fixtures/nosyntax-with-lang.md
+++ b/test/fixtures/nosyntax-with-lang.md
@@ -1,0 +1,8 @@
+%{
+  syntax: "nohighlight"
+}
+---
+
+```elixir
+IO.puts "syntax"
+```

--- a/test/fixtures/nosyntax-with-lang.md
+++ b/test/fixtures/nosyntax-with-lang.md
@@ -1,5 +1,5 @@
 %{
-  syntax: "nohighlight"
+  syntax: false
 }
 ---
 

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -72,7 +72,7 @@ defmodule NimblePublisherTest do
         from: "test/fixtures/nosyntax-with-lang.md",
         as: :examples
 
-      assert hd(@examples).attrs == %{syntax: "nohighlight"}
+      assert hd(@examples).attrs == %{syntax: false}
 
       assert hd(@examples).body =~
                "<pre><code class=\"elixir\">IO.puts &quot;syntax&quot;</code></pre>"

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -31,7 +31,7 @@ defmodule NimblePublisherTest do
                %{filename: "markdown.md"},
                %{filename: "nosyntax-with-lang.md"},
                %{filename: "nosyntax.md"},
-               %{filename: "syntax.md"},
+               %{filename: "syntax.md"}
              ] =
                @examples
                |> update_in([Access.all(), :filename], &Path.basename/1)
@@ -73,7 +73,9 @@ defmodule NimblePublisherTest do
         as: :examples
 
       assert hd(@examples).attrs == %{syntax: "nohighlight"}
-      assert hd(@examples).body =~ "<pre><code class=\"elixir\">IO.puts &quot;syntax&quot;</code></pre>"
+
+      assert hd(@examples).body =~
+               "<pre><code class=\"elixir\">IO.puts &quot;syntax&quot;</code></pre>"
     end
   end
 

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -23,13 +23,15 @@ defmodule NimblePublisherTest do
       use NimblePublisher,
         build: Builder,
         from: "test/fixtures/**/*.md",
-        as: :examples
+        as: :examples,
+        highlighters: []
 
       assert [
                %{filename: "crlf.md"},
                %{filename: "markdown.md"},
+               %{filename: "nosyntax-with-lang.md"},
                %{filename: "nosyntax.md"},
-               %{filename: "syntax.md"}
+               %{filename: "syntax.md"},
              ] =
                @examples
                |> update_in([Access.all(), :filename], &Path.basename/1)
@@ -60,6 +62,18 @@ defmodule NimblePublisherTest do
 
       assert hd(@examples).attrs == %{syntax: "nohighlight"}
       assert hd(@examples).body =~ "<pre><code>IO.puts &quot;syntax&quot;</code></pre>"
+    end
+  end
+
+  test "handles code blocks with language" do
+    defmodule Example do
+      use NimblePublisher,
+        build: Builder,
+        from: "test/fixtures/nosyntax-with-lang.md",
+        as: :examples
+
+      assert hd(@examples).attrs == %{syntax: "nohighlight"}
+      assert hd(@examples).body =~ "<pre><code class=\"elixir\">IO.puts &quot;syntax&quot;</code></pre>"
     end
   end
 


### PR DESCRIPTION
I've noticed that with `%{syntax: "nohighlight"}`, a code block with `elixir` lang identifier is still *highlighted*. Should the `"nohighlight"` option completely disable the syntax highlighting?

#### input.md

<pre>
%{
  syntax: "nohighlight"
}
---

```elixir
IO.puts "syntax"
```
</pre>

### Actual post body

```elixir
"<pre><code class=\"makeup elixir\"><span class=\"nc\">IO</span><span class=\"o\">.</span><span class=\"n\">puts</span><span class=\"w\"> </span><span class=\"s\">&quot;syntax&quot;</span></code></pre>\n"
```

### Expected post body

```elixir
"<pre><code class=\"elixir\">IO.puts &quot;syntax&quot;</code></pre>"
```


