### PR TITLE
allow also for key value attributes in place of elixir map 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ A typical blog post will look like this:
     ---
     This is the post.
 
+You can also use key key value pairs, but then you need to parse the values
+that are not strings in your code like tags in this example
+
+    # /posts/2020/04-17-hello-world.md
+      title: Hello world!
+      author: José Valim
+      tags: hello,world
+      description: Let's learn how to say hello world
+    ---
+    This is the post.
+
 Therefore, we will define a Post struct that expects all of the fields
 above. We will also have a `:date` field that we will build from the
 filename. Overall, it will look like this:

--- a/test/fixtures/invalid.map
+++ b/test/fixtures/invalid.map
@@ -1,0 +1,3 @@
+%{hello:}
+---
+this is the body

--- a/test/fixtures/invalid.nomap
+++ b/test/fixtures/invalid.nomap
@@ -1,3 +1,4 @@
 "hello"
 ---
 This is also invalid.
+

--- a/test/fixtures/keyvalue.md
+++ b/test/fixtures/keyvalue.md
@@ -1,0 +1,6 @@
+hello: world
+multiple: words in one line
+tags: comma,separated,values
+description: string: with separator
+---
+body

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -27,6 +27,7 @@ defmodule NimblePublisherTest do
 
       assert [
                %{filename: "crlf.md"},
+               %{filename: "keyvalue.md"},
                %{filename: "markdown.md"},
                %{filename: "nosyntax.md"},
                %{filename: "syntax.md"}
@@ -124,6 +125,23 @@ defmodule NimblePublisherTest do
     end
   end
 
+  test "properly parses key value attributes" do
+    defmodule Example do
+      use NimblePublisher,
+        build: Builder,
+        from: "test/fixtures/keyvalue.md",
+        as: :highlights,
+        highlighters: [:makeup_elixir]
+
+      assert hd(@highlights).attrs == %{
+               description: "string: with separator",
+               hello: "world",
+               tags: "comma,separated,values",
+               multiple: "words in one line"
+             }
+    end
+  end
+
   test "does not require recompilation unless paths changed" do
     defmodule Example do
       use NimblePublisher,
@@ -166,7 +184,20 @@ defmodule NimblePublisherTest do
                  end
   end
 
-  test "raises if not a map" do
+  test "raises if invalid map" do
+    assert_raise RuntimeError,
+                 ~r/expected attributes for \"test\/fixtures\/invalid.map\" to return a map/,
+                 fn ->
+                   defmodule Example do
+                     use NimblePublisher,
+                       build: Builder,
+                       from: "test/fixtures/invalid.map",
+                       as: :example
+                   end
+                 end
+  end
+
+  test "raises if not key value pairs" do
     assert_raise RuntimeError,
                  ~r/expected attributes for \"test\/fixtures\/invalid.nomap\" to return a map/,
                  fn ->


### PR DESCRIPTION
 it's looking a bit similar to [front-matter](https://jekyllrb.com/docs/front-matter/) syntax, but without external dependencies.
 And it still allows for adding  front matter in the future because it requires the use of `---` at the beginning
 I think its a bit easier to create than valid maps in the header.
```
title: Hello world!
author: José Valim
tags: hello,world
description: Let's learn how to say hello world
---
body
```