### PR TITLE
Add support for custom markdown parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,8 @@ defmodule MarkdownConverter do
   def convert_body(extname, body, opts) when extname in [".md", ".markdown"] do
     highlighters = Keyword.get(opts, :highlighters, [])
     
-    html = Md.generate(body) |> highlight(highlighters)
+    Md.generate(body) |> NimblePublisher.highlight(highlighters)
   end
-
-  def convert_body(".html", body, _opts) do
-    body
-  end
-
-  defp highlight(html, []), do: html
-  defp highlight(html, _), do: NimblePublisher.Highlighter.highlight(html)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,17 +51,19 @@ Each article in the articles directory must have the format:
     `Makeup.stylesheet(:vim_style, "makeup")` inside `iex -S mix`.
     You can replace `:vim_style` by any style of your choice
     [defined here](https://elixir-makeup.github.io/makeup_demo/elixir.html).
-    When using a custom `:converter`, you will need to call this
-    manually, as shown in the [Custom markdown converter](#custom-markdown-converter)
-    section.
+    
+    When using a custom `:html_converter`, you will need to call
+    `NiblePublisher.highlight/3` manually, as shown in the 
+    [Custom markdown converter](#custom-markdown-converter) section.
 
   * `:earmark_options` - an [`%Earmark.Options{}`](https://hexdocs.pm/earmark/Earmark.Options.html) struct
 
   * `:parser` - custom module with a `parse/2` function that receives the file path
     and content as params. See [Custom parser](#custom-parser) for more details.
 
-  * `:converter` - custom module with a `convert_body/3` function that receives the
-    body of the markdown file as a param. See [Custom markdown converter](#custom-markdown-converter)
+  * `:html_converter` - custom module with a `convert/4` function that receives the
+    extension, body, and attributes of the markdown file, as well as all options 
+    as params. See [Custom markdown converter](#custom-markdown-converter)
     for more details.
 
 ## Examples
@@ -205,18 +207,18 @@ It must return:
 You can also define a custom markdown converter that will be used to convert the
 body of the from markdown into some other format such as HTML. For example, you
 may wish to use an alternative markdown parser such as
-[md](https://github.com/am-kantox/md). Because the `convert_body/3` function
-does not need to return HTML, if we want to use the built-in highlighting, we
+[md](https://github.com/am-kantox/md). Because the `convert/4` function
+does not need to return HTML, if you want to use the built-in highlighting, you
 need to call it manually.
 
 ```elixir
   use NimblePublisher,
     ...
-    converter: MarkdownConverter,
+    html_converter: MarkdownConverter,
     highlighters: [:makeup_elixir]
 
 defmodule MarkdownConverter do
-  def convert_body(extname, body, opts) when extname in [".md", ".markdown"] do
+  def convert(extname, body, _attrs, opts) when extname in [".md", ".markdown"] do
     highlighters = Keyword.get(opts, :highlighters, [])
     
     Md.generate(body) |> NimblePublisher.highlight(highlighters)
@@ -224,9 +226,9 @@ defmodule MarkdownConverter do
 end
 ```
 
-The `convert_body/3` function from this module receives an extension name,
-a body and the options passed to `NimblePublisher`. It must return the converted
-body as a string. 
+The `convert/4` function from this module receives an extension name, a body,
+the parsed attributes from the file, and the options passed to
+`NimblePublisher`. It must return the converted body as a string. 
 
 ### Live reloading
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Each article in the articles directory must have the format:
   * `:parser` - custom module with a `parse/2` function that receives the file path
     and content as params. See [Custom parser](#custom-parser) for more details.
 
+  * `:markdown_parser` - custom module with a `parse/1` function that receives the
+    body of the markdown file as a param. See [Custom markdown parser](#custom-markdown-parser)
+    for more details.
+
 ## Examples
 
 Let's see a complete example. First add `nimble_publisher` with
@@ -192,6 +196,28 @@ It must return:
 
   * a 2 element tuple with attributes and body - `{attrs, body}`
   * a list of 2 element tuple with attributes and body - `[{attrs, body} | _]`
+
+### Custom markdown parser
+
+You can also define a custom markdown parser that will be used to convert the of
+the from markdown file into HTML. For example, you may wish to use an
+alternative markdown parser such as [md](https://github.com/am-kantox/md).
+
+```elixir
+  use NimblePublisher,
+    ...
+    markdown_parser: MarkdownParser,
+
+defmodule MarkdownParser do
+  def parse(body) do
+    # Custom markdown parser
+    Md.generate(body)
+  end
+end
+```
+
+The `parse/1` function from this module receives markdown body.
+It should return return a HTML body.
 
 ### Live reloading
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ Each article in the articles directory must have the format:
     `Makeup.stylesheet(:vim_style, "makeup")` inside `iex -S mix`.
     You can replace `:vim_style` by any style of your choice
     [defined here](https://elixir-makeup.github.io/makeup_demo/elixir.html).
-    
-    When using a custom `:html_converter`, you will need to call
-    `NiblePublisher.highlight/3` manually, as shown in the 
-    [Custom markdown converter](#custom-markdown-converter) section.
 
   * `:earmark_options` - an [`%Earmark.Options{}`](https://hexdocs.pm/earmark/Earmark.Options.html) struct
 
@@ -63,8 +59,7 @@ Each article in the articles directory must have the format:
 
   * `:html_converter` - custom module with a `convert/4` function that receives the
     extension, body, and attributes of the markdown file, as well as all options 
-    as params. See [Custom markdown converter](#custom-markdown-converter)
-    for more details.
+    as params. See [Custom HTML converter](#custom-html-converter) for more details.
 
 ## Examples
 
@@ -202,26 +197,25 @@ It must return:
   * a 2 element tuple with attributes and body - `{attrs, body}`
   * a list of 2 element tuple with attributes and body - `[{attrs, body} | _]`
 
-### Custom markdown converter
+### Custom HTML converter
 
-You can also define a custom markdown converter that will be used to convert the
-body of the from markdown into some other format such as HTML. For example, you
-may wish to use an alternative markdown parser such as
-[md](https://github.com/am-kantox/md). Because the `convert/4` function
-does not need to return HTML, if you want to use the built-in highlighting, you
-need to call it manually.
+You can also define a custom HTML converter that will be used to convert the
+file body (typically Markdown) into HTML. For example, you may wish to use an
+alternative Markdown parser such as [md](https://github.com/am-kantox/md).
+If you want to use the built-in highlighting, you need to call it manually.
 
 ```elixir
   use NimblePublisher,
     ...
     html_converter: MarkdownConverter,
     highlighters: [:makeup_elixir]
+```
 
+```elixir
 defmodule MarkdownConverter do
   def convert(extname, body, _attrs, opts) when extname in [".md", ".markdown"] do
     highlighters = Keyword.get(opts, :highlighters, [])
-    
-    Md.generate(body) |> NimblePublisher.highlight(highlighters)
+    body |> Md.generate() |> NimblePublisher.highlight(highlighters)
   end
 end
 ```

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -49,6 +49,9 @@ defmodule NimblePublisher do
 
   @doc """
   Highlights all code blocks in an already generated HTML document.
+  
+  It uses Makeup and expects the existing highlighters applications to
+  be already started.
 
   Options:
 

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -116,7 +116,15 @@ defmodule NimblePublisher do
   defp convert_body(extname, body, opts) when extname in [".md", ".markdown", ".livemd"] do
     earmark_opts = Keyword.get(opts, :earmark_options, %Earmark.Options{})
     highlighters = Keyword.get(opts, :highlighters, [])
-    body |> Earmark.as_html!(earmark_opts) |> highlight(highlighters)
+    markdown_parser_module = Keyword.get(opts, :markdown_parser)
+
+    html_body =
+      case markdown_parser_module do
+        nil -> Earmark.as_html!(body, earmark_opts)
+        module -> module.parse(body)
+      end
+
+    html_body |> highlight(highlighters)
   end
 
   defp convert_body(_extname, body, _opts) do

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -73,19 +73,19 @@ defmodule NimblePublisher do
     NimblePublisher.Highlighter.highlight(html, options)
   end
 
-  defp build_entry(builder, path, {_attr, _body} = parsed_contents, opts) do
+  defp build_entry(builder, path, {_attrs, _body} = parsed_contents, opts) do
     build_entry(builder, path, [parsed_contents], opts)
   end
 
   defp build_entry(builder, path, parsed_contents, opts) when is_list(parsed_contents) do
-    converter_module = Keyword.get(opts, :converter)
+    converter_module = Keyword.get(opts, :html_converter)
     extname = Path.extname(path) |> String.downcase()
 
     Enum.map(parsed_contents, fn {attrs, body} ->
       body =
         case converter_module do
           nil -> convert_body(extname, body, opts)
-          module -> module.convert_body(extname, body, opts)
+          module -> module.convert(extname, body, attrs, opts)
         end
 
       builder.build(path, attrs, body)

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -47,6 +47,32 @@ defmodule NimblePublisher do
     {from, paths}
   end
 
+  @doc """
+  Highlights all code blocks in an already generated HTML document.
+
+  Options:
+
+    * `:regex` - the regex used to find code blocks in the HTML document. The regex
+      should have two capture groups: the first one should be the language name
+      and the second should contain the code to be highlighted. The default
+      regex to match with generated HTML documents is:
+
+          ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/
+  """
+  def highlight(html, highlighters, options \\ [])
+
+  def highlight(html, [], _options) do
+    html
+  end
+
+  def highlight(html, highlighters, options) when is_list(highlighters) do
+    for highlighter <- highlighters do
+      Application.ensure_all_started(highlighter)
+    end
+
+    NimblePublisher.Highlighter.highlight(html, options)
+  end
+
   defp build_entry(builder, path, {_attr, _body} = parsed_contents, opts) do
     build_entry(builder, path, [parsed_contents], opts)
   end
@@ -64,14 +90,6 @@ defmodule NimblePublisher do
 
       builder.build(path, attrs, body)
     end)
-  end
-
-  defp highlight(html, []) do
-    html
-  end
-
-  defp highlight(html, _) do
-    NimblePublisher.Highlighter.highlight(html)
   end
 
   defp parse_contents!(path, contents, nil) do

--- a/lib/nimble_publisher/highlighter.ex
+++ b/lib/nimble_publisher/highlighter.ex
@@ -4,9 +4,14 @@ defmodule NimblePublisher.Highlighter do
   @doc """
   Highlights all code block in an already generated HTML document.
   """
-  def highlight(html) do
+
+  @default_regex ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/
+
+  def highlight(html, options \\ []) do
+    regex = Keyword.get(options, :regex, @default_regex)
+
     Regex.replace(
-      ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/,
+      regex,
       html,
       &highlight_code_block(&1, &2, &3)
     )

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -180,7 +180,7 @@ defmodule NimblePublisherTest do
 
   test "allows for custom markdown parsing function returning parsed html" do
     defmodule MarkdownConverter do
-      def convert_body(extname, body, opts) do
+      def convert_body(extname, _body, opts) do
         from = Keyword.get(opts, :from)
 
         "<p>This is a custom markdown converter from a #{extname} file, from the #{from} file</p>\n"
@@ -223,5 +223,27 @@ defmodule NimblePublisherTest do
                        as: :example
                    end
                  end
+  end
+
+  test "highlights code blocks" do
+    higlighters = [:makeup_elixir, :makeup_erlang]
+    input = "<pre><code class=\"elixir\">IO.puts(\"Hello World\")</code></pre>"
+    output = NimblePublisher.highlight(input, higlighters)
+
+    assert output =~ "<pre><code class=\"makeup elixir\"><span class=\"nc\">IO"
+  end
+
+  test "highlights code blocks with custom regex" do
+    highlighters = [:makeup_elixir]
+    input = "<code lang=\"elixir\">IO.puts(\"Hello World\")</code>"
+
+    output =
+      NimblePublisher.highlight(
+        input,
+        highlighters,
+        regex: ~r/<code(?:\s+lang="(\w*)")?>([^<]*)<\/code>/
+      )
+
+    assert output =~ "<pre><code class=\"makeup elixir\"><span class=\"nc\">"
   end
 end

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -178,6 +178,24 @@ defmodule NimblePublisherTest do
     end
   end
 
+  test "allows for custom markdown parsing function returning parsed html" do
+    defmodule MarkdownParser do
+      def parse(body) do
+        "<p>This is a custom markdown parser</p>\n"
+      end
+    end
+
+    defmodule Example do
+      use NimblePublisher,
+        build: Builder,
+        from: "test/fixtures/markdown.md",
+        as: :custom,
+        markdown_parser: MarkdownParser
+
+      assert hd(@custom).body == "<p>This is a custom markdown parser</p>\n"
+    end
+  end
+
   test "raises if missing separator" do
     assert_raise RuntimeError,
                  ~r/could not find separator --- in "test\/fixtures\/invalid.noseparator"/,

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -179,9 +179,11 @@ defmodule NimblePublisherTest do
   end
 
   test "allows for custom markdown parsing function returning parsed html" do
-    defmodule MarkdownParser do
-      def parse(body) do
-        "<p>This is a custom markdown parser</p>\n"
+    defmodule MarkdownConverter do
+      def convert_body(extname, body, opts) do
+        from = Keyword.get(opts, :from)
+
+        "<p>This is a custom markdown converter from a #{extname} file, from the #{from} file</p>\n"
       end
     end
 
@@ -190,9 +192,10 @@ defmodule NimblePublisherTest do
         build: Builder,
         from: "test/fixtures/markdown.md",
         as: :custom,
-        markdown_parser: MarkdownParser
+        converter: MarkdownConverter
 
-      assert hd(@custom).body == "<p>This is a custom markdown parser</p>\n"
+      assert hd(@custom).body ==
+               "<p>This is a custom markdown converter from a .md file, from the test/fixtures/markdown.md file</p>\n"
     end
   end
 

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -180,10 +180,10 @@ defmodule NimblePublisherTest do
 
   test "allows for custom markdown parsing function returning parsed html" do
     defmodule MarkdownConverter do
-      def convert_body(extname, _body, opts) do
+      def convert(extname, _body, attrs, opts) do
         from = Keyword.get(opts, :from)
 
-        "<p>This is a custom markdown converter from a #{extname} file, from the #{from} file</p>\n"
+        "<p>This is a custom markdown converter from a #{extname} file, from the #{from} file, hello #{attrs.hello}</p>\n"
       end
     end
 
@@ -192,10 +192,10 @@ defmodule NimblePublisherTest do
         build: Builder,
         from: "test/fixtures/markdown.md",
         as: :custom,
-        converter: MarkdownConverter
+        html_converter: MarkdownConverter
 
       assert hd(@custom).body ==
-               "<p>This is a custom markdown converter from a .md file, from the test/fixtures/markdown.md file</p>\n"
+               "<p>This is a custom markdown converter from a .md file, from the test/fixtures/markdown.md file, hello world</p>\n"
     end
   end
 


### PR DESCRIPTION
Use case: I want to use a custom markdown parser ([md](https://github.com/am-kantox/md)) instead of Earmark, in order to use my own markdown format with support for `HEEx` inside of markdown.

Example usage:
```elixir
  use NimblePublisher,
    ...
    markdown_parser: MarkdownParser,

defmodule MarkdownParser do
  def parse(body) do
     "<p>This is a custom markdown parser :)</p>\n"
  end
end
```