### PR TITLE
Refactor the GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
               otp: 23.3.2
             lint: lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,22 @@ on:
   push:
 
 jobs:
+  lint:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@v2
+
+        - uses: erlef/setup-beam@v1
+          with:
+            otp-version: 25.x
+            elixir-version: 1.x
+
+        - run: mix deps.get
+        - run: mix deps.unlock --check-unused
+        - run: mix deps.compile
+        - run: mix compile --warnings-as-errors
+        - run: mix format --check-formatted
+
   test:
     runs-on: ubuntu-20.04
     env:
@@ -12,41 +28,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pair:
-              elixir: 1.7.4
-              otp: 19.3.6.13
-          - pair:
-              elixir: 1.11.4
-              otp: 23.3.2
-            lint: lint
+          - versions:
+              otp: 22.x
+              elixir: 1.12.x
+          - versions:
+              otp: 26.x
+              elixir: 1.x
     steps:
       - uses: actions/checkout@v3
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.pair.otp}}
-          elixir-version: ${{matrix.pair.elixir}}
+          otp-version: ${{ matrix.versions.otp }}
+          elixir-version: ${{ matrix.versions.elixir }}
 
       - uses: actions/cache@v3
         with:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ matrix.versions.elixir }}-${{ matrix.versions.otp }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-
 
       - run: mix deps.get
-
-      - run: mix format --check-formatted
-        if: ${{ matrix.lint }}
-
-      - run: mix deps.unlock --check-unused
-        if: ${{ matrix.lint }}
-
       - run: mix deps.compile
-
-      - run: mix compile --warnings-as-errors
-        if: ${{ matrix.lint }}
-
+      - run: mix compile
       - run: mix test

--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -49,7 +49,7 @@ defmodule NimblePublisher do
 
   @doc """
   Highlights all code blocks in an already generated HTML document.
-  
+
   It uses Makeup and expects the existing highlighters applications to
   be already started.
 


### PR DESCRIPTION
Hi,

After playing with NimblePublished a bit, I ended up noticing [the project is having some trouble with the CI workflow](https://github.com/dashbitco/nimble_publisher/commit/7ab6a422b9a0a6dec8715b2e1b3c73c06378c5c6). So I decided to help.

First of all, code-linting tasks were moved to a dedicated job, for a better experience when linting-related issues arise, and `mix format` was executed to fix some remaining minor issues.

So, it seems to me the [erlef/setup-beam](https://github.com/erlef/setup-beam) action is unable to set up OTP 19-based Elixir binaries since [Ubuntu 18.04 became unavailable in GitHub Actions](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/). Given that [erlef/setup-beam needs it to provide OTP 19 binaries](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp), the respective job was failing.

Anyway. After hours of struggle and reading the documentation for GitHub Actions and erlef/setup-beam itself, I'm convinced it's currently not possible to get the CI up again without bumping these versions. So, I did.

But I also realized there's a hard dependency on Elixir 1.12.x for this `earmark` dependency:

```
$ mix deps.compile
==> earmark_parser
Compiling 3 files (.erl)
Compiling 46 files (.ex)
Generated earmark_parser app
==> nimble_parsec
Compiling 4 files (.ex)
Generated nimble_parsec app
==> makeup
Compiling 44 files (.ex)
Generated makeup app
==> earmark
warning: the dependency :earmark requires Elixir "~> 1.12" but you are running on v1.11.4
Compiling 15 files (.ex)
DEPRECATION WARNING: versions < 1.12.0 of Elixir are not tested anymore and will not be supported in Earmark v1.5

== Compilation error in file lib/earmark/restructure.ex ==
Error: ** (SyntaxError) lib/earmark/restructure.ex:47:1: invalid location for heredoc terminator, please escape token or move it to its own line: """
    (elixir 1.11.4) lib/kernel/parallel_compiler.ex:314: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
could not compile dependency :earmark, "mix compile" failed. You can recompile this dependency with "mix deps.compile earmark", update it with "mix deps.update earmark" or clean it with "mix deps.clean earmark"
Error: Process completed with exit code 1.
```

So, I bumped the older OTP and Elixir versions to 22 and 1.12.x (the oldest OTP version available through erlef/setup-beam under ubuntu-20.04; again, 20.x and 21.x didn't seem to work), while the newest ones I bumped to 26.x and 1.x (so we can run tests against the most recent versions for Erlang/OTP and Elixir itself). I didn't know why OTP 19/23 and Elixir 1.7.4/1.11.4 specifically were being used, but I'm assuming these configurations are just outdated.

In the end, this rewrite made the workflow in my fork repository shine green again. :)