### PR TITLE
Update couple of internal section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ Each article in the articles directory must have the format:
   * `:earmark_options` - an [`%Earmark.Options{}`](https://hexdocs.pm/earmark/Earmark.Options.html) struct
 
   * `:parser` - custom module with a `parse/2` function that receives the file path
-    and content as params. See [Custom parser](#custom-parser) for more details.
+    and content as params. See [Custom parser](#module-custom-parser) for more details.
 
   * `:html_converter` - custom module with a `convert/4` function that receives the
     extension, body, and attributes of the markdown file, as well as all options
-    as params. See [Custom HTML converter](#custom-html-converter) for more details.
+    as params. See [Custom HTML converter](#module-custom-html-converter) for more details.
 
 ## Examples
 


### PR DESCRIPTION
> **Disclaimer:** I am not sure if that is the problem of NimblePublisher docs, or ExDocs' library which generated different anchor value for the sections. See explanation below.

It appears that there are a couple of _(broken?)_ links in the README: while I was reading the docs, I noticed that `Custom parser` and `Custom HTML converter` links lead nowhere. 

Even though we have both of these sections in the document, their anchors have a `module-` prefix, check this Developer Tools screenshot (made at https://hexdocs.pm/nimble_publisher/NimblePublisher.html page):

<img width="629" alt="image" src="https://github.com/dashbitco/nimble_publisher/assets/113878/8ff9183c-186c-41d0-98fb-4b849a68cd19">

That leads to the broken navigation.

_P.S. As I mentioned in the “disclaimer”, it could be an issue of ExDoc which prefixed anchors for some reason, because logically, it should leave them non-prefixed – as they are defined in the original README._