### PR TITLE
Use a more relaxed language pattern in code highlight regex

### DIFF
--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -60,7 +60,7 @@ defmodule NimblePublisher do
       and the second should contain the code to be highlighted. The default
       regex to match with generated HTML documents is:
 
-          ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/
+          ~r/<pre><code(?:\s+class="([^"\s]*)")?>([^<]*)<\/code><\/pre>/
   """
   defdelegate highlight(html, options \\ []), to: NimblePublisher.Highlighter
 

--- a/lib/nimble_publisher/highlighter.ex
+++ b/lib/nimble_publisher/highlighter.ex
@@ -5,7 +5,7 @@ defmodule NimblePublisher.Highlighter do
   Highlights all code block in an already generated HTML document.
   """
 
-  @default_regex ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/
+  @default_regex ~r/<pre><code(?:\s+class="([^"\s]*)")?>([^<]*)<\/code><\/pre>/
 
   def highlight(html, options \\ []) do
     regex = Keyword.get(options, :regex, @default_regex)


### PR DESCRIPTION
Fix highlighting for `` ```c++ `` snippets, same as https://github.com/elixir-lang/ex_doc/pull/2092.