### PR TITLE
use Task.async_stream to parse and build entries

### DIFF
--- a/lib/nimble_publisher.ex
+++ b/lib/nimble_publisher.ex
@@ -39,10 +39,13 @@ defmodule NimblePublisher do
 
     entries =
       paths
-      |> Task.async_stream(fn path ->
-        parsed_contents = parse_contents!(path, File.read!(path), parser_module)
-        build_entry(builder, path, parsed_contents, opts)
-      end)
+      |> Task.async_stream(
+        fn path ->
+          parsed_contents = parse_contents!(path, File.read!(path), parser_module)
+          build_entry(builder, path, parsed_contents, opts)
+        end,
+        timeout: :infinity
+      )
       |> Enum.flat_map(fn
         {:ok, results} -> results
         _ -> []

--- a/test/nimble_publisher_test.exs
+++ b/test/nimble_publisher_test.exs
@@ -200,29 +200,41 @@ defmodule NimblePublisherTest do
   end
 
   test "raises if missing separator" do
-    assert_raise RuntimeError,
-                 ~r/could not find separator --- in "test\/fixtures\/invalid.noseparator"/,
-                 fn ->
-                   defmodule Example do
-                     use NimblePublisher,
-                       build: Builder,
-                       from: "test/fixtures/invalid.noseparator",
-                       as: :example
-                   end
-                 end
+    Process.flag(:trap_exit, true)
+
+    pid =
+      spawn_link(fn ->
+        defmodule Example do
+          use NimblePublisher,
+            build: Builder,
+            from: "test/fixtures/invalid.noseparator",
+            as: :example
+        end
+      end)
+
+    assert_receive {:EXIT, ^pid, {%RuntimeError{} = error, _exception}}
+
+    assert Exception.message(error) =~
+             ~r/could not find separator --- in "test\/fixtures\/invalid.noseparator"/
   end
 
   test "raises if not a map" do
-    assert_raise RuntimeError,
-                 ~r/expected attributes for \"test\/fixtures\/invalid.nomap\" to return a map/,
-                 fn ->
-                   defmodule Example do
-                     use NimblePublisher,
-                       build: Builder,
-                       from: "test/fixtures/invalid.nomap",
-                       as: :example
-                   end
-                 end
+    Process.flag(:trap_exit, true)
+
+    pid =
+      spawn_link(fn ->
+        defmodule Example do
+          use NimblePublisher,
+            build: Builder,
+            from: "test/fixtures/invalid.nomap",
+            as: :example
+        end
+      end)
+
+    assert_receive {:EXIT, ^pid, {%RuntimeError{} = error, _exception}}
+
+    assert Exception.message(error) =~
+             ~r/expected attributes for \"test\/fixtures\/invalid.nomap\" to return a map/
   end
 
   test "highlights code blocks" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
This change should improve the performance when building the entries in general.

I did a small test with the Elixir School content and I got the following results:

## Before

```console
$ cd school_lite
$ time mix compile --force
Generated school_lite app

real    0m9.026s
user    0m8.344s
sys     0m1.893s

Generated school_lite app

real    0m9.332s
user    0m8.583s
sys     0m2.048s

Generated school_lite app

real    0m9.095s
user    0m8.353s
sys     0m2.007s
```

## After

```console
Generated school_lite app

real    0m3.966s
user    0m8.057s
sys     0m2.168s

Generated school_lite app

real    0m3.883s
user    0m8.066s
sys     0m2.220s

Generated school_lite app

real    0m3.848s
user    0m8.021s
sys     0m2.186s
```

Here is the "School Lite" version I created from the source code available at: https://github.com/elixirschool/school_house

```elixir
defmodule SchoolLite.Content.Conference do
  @enforce_keys [:name, :link, :date]
  defstruct [
    :name,
    :link,
    :date,
    :series,
    :location,
    :country
  ]

  def build(_filename, attrs, _body) do
    struct!(__MODULE__, Map.to_list(attrs))
  end
end

defmodule SchoolLite.Content.Podcast do
  @enforce_keys [:about, :active, :logo, :name, :website]
  defstruct [
    :about,
    :active,
    :language,
    :logo,
    :name,
    :website
  ]

  def build(_filename, attrs, _body) do
    struct!(__MODULE__, Map.to_list(attrs))
  end
end

defmodule SchoolLite.Content.Post do
  @enforce_keys [:author, :author_link, :body, :date, :excerpt, :slug, :tags, :title, :title_text]
  defstruct [
    :author,
    :author_link,
    :body,
    :date,
    :excerpt,
    :slug,
    :tags,
    :title,
    :title_text
  ]

  def build(filename, attrs, body) do
    date_prefix_length = 11

    slug =
      filename
      |> Path.basename(".md")
      |> String.slice(date_prefix_length..-1//1)

    {title_text, attrs} = Map.pop!(attrs, :title)
    {excerpt, attrs} = Map.pop!(attrs, :excerpt)

    attrs =
      attrs
      |> Map.put(:title_text, title_text)
      |> Map.put(:title, Earmark.as_html!(title_text))
      |> Map.put(:excerpt, Earmark.as_html!(excerpt))

    struct!(__MODULE__, [body: body, slug: slug] ++ Map.to_list(attrs))
  end
end

defmodule SchoolLite.Content.Lesson do
  @enforce_keys [:body, :section, :locale, :name, :title, :version]

  defstruct [
    :body,
    :excerpt,
    :locale,
    :name,
    :next,
    :previous,
    :redirect_from,
    :section,
    :table_of_contents,
    :title,
    :version
  ]

  def build(filename, attrs, body) do
    [locale, section, name] =
      filename
      |> Path.rootname()
      |> Path.split()
      |> Enum.take(-3)

    filename_attrs = [
      body: body,
      locale: locale,
      excerpt: "excerpt",
      name: String.to_atom(name),
      section: String.to_atom(section),
      table_of_contents: "",
      version: "version"
    ]

    struct!(__MODULE__, Map.to_list(attrs) ++ filename_attrs)
  end
end

defmodule SchoolLite.Lessons do
  use NimblePublisher,
    build: SchoolLite.Content.Lesson,
    from: "content/lessons/**/*.md",
    as: :lessons,
    highlighters: [:makeup_elixir, :makeup_erlang]

  def all, do: @lessons
end

defmodule SchoolLite.Posts do
  use NimblePublisher,
    build: SchoolLite.Content.Post,
    from: "content/posts/**/*.md",
    as: :posts,
    highlighters: [:makeup_elixir, :makeup_erlang]

  def all, do: @posts
end

defmodule SchoolLite.Conferences do
  use NimblePublisher,
    build: SchoolLite.Content.Conference,
    from: "content/conferences/*.md",
    as: :conferences

  def all, do: @conferences
end

defmodule SchoolLite.Podcasts do
  use NimblePublisher,
    build: SchoolLite.Content.Podcast,
    from: "content/podcasts/*.md",
    as: :podcasts,
    highlighters: [:makeup_elixir, :makeup_erlang]

  def all, do: @podcasts
end
```