### PR TITLE
Silence Makeup.Registry warnings

### DIFF
--- a/lib/nimble_publisher/highlighter.ex
+++ b/lib/nimble_publisher/highlighter.ex
@@ -5,7 +5,7 @@ defmodule NimblePublisher.Highlighter do
   Highlights all code block in an already generated HTML document.
   """
 
-  @compile {:no_warn_undefined, Makeup}
+  @compile {:no_warn_undefined, [Makeup, Makeup.Registry]}
   @default_regex ~r/<pre><code(?:\s+class="([^"\s]*)")?>([^<]*)<\/code><\/pre>/
 
   def highlight(html, options \\ []) do


### PR DESCRIPTION
The main Makeup module was silenced but `Makeup.Registry` is also being used. I'm using NimblePublisher and MDEx and I'm seeing

```
==> nimble_publisher
Compiling 2 files (.ex)
    warning: Makeup.Registry.fetch_lexer_by_name/1 is undefined (module Makeup.Registry is not available or is yet to be defined)
    │
 35 │     case Makeup.Registry.fetch_lexer_by_name(lang) do
    │                          ~
    │
    └─ lib/nimble_publisher/highlighter.ex:35:26: NimblePublisher.Highlighter.pick_language_and_lexer/1
```

when compiling. This PR adds `Makeup.Registry` to the `no_warn_undefined`.